### PR TITLE
fix: Ticket Entity Unique Key 정렬 순서 변경

### DIFF
--- a/src/main/java/stack/moaticket/domain/ticket/entity/Ticket.java
+++ b/src/main/java/stack/moaticket/domain/ticket/entity/Ticket.java
@@ -23,8 +23,8 @@ import java.time.LocalDateTime;
         name = "ticket",
         uniqueConstraints = {
                 @UniqueConstraint(
-                        name = "uk_seat_session_id",
-                        columnNames = {"seat_id", "session_id"}
+                        name = "uk_session_seat_id",
+                        columnNames = {"session_id", "seat_id"}
                 )
         })
 public class Ticket extends Base {


### PR DESCRIPTION
## 🔥 Related Issues
<!-- resolved, close, fix 중 하나를 사용하면 머지 시 이슈가 자동으로 닫힙니다 -->
resolved #issue_number

## 💜 작업 내용
Unique Key의 인덱스 효율을 위해 정렬 순서를 변경하였습니다.

- [x] ~ 기능 구현
## ✅ PR Point
- **변경 이유**: 기존 Ticket의 Unique Key 순서가 Seat-Session으로 지정되어 Seat 순서대로 먼저 정렬이 되고 Session 정렬이 되어 비효율적인 문제가 있었습니다. 이를 해결하기 위해 순서를 Session-Seat로 지정하여 SessionId 우선 정렬로 변경하여 인덱스 효율성을 향상시켰습니다.
- **주의사항**: -
- **리뷰 포인트**: -

## 🧪 테스트 체크리스트
- [x] 로컬에서 정상 작동 확인

---
## 📝 Self Review
<!-- 본인이 작성한 코드를 한 번 더 점검해주세요 -->
- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 주석이나 콘솔 로그를 제거했나요?
- [x] 커밋 메시지가 명확한가요?
- [x] 중복 코드는 없나요?