### PR TITLE
fix: chatting 동일 아이디로 동일 방에 존재할 시, 새로고침할 때 정상적으로 채팅에 참여가 되는것 수정

### DIFF
--- a/src/main/java/stack/moaticket/application/component/registry/StompRoomRegistry.java
+++ b/src/main/java/stack/moaticket/application/component/registry/StompRoomRegistry.java
@@ -65,11 +65,12 @@ public class StompRoomRegistry {
         if (roomId == null || memberId == null) return;
 
         roomMemberSessionMap.computeIfPresent(roomId, (rId, userSessionMap) -> {
-            userSessionMap.remove(memberId);
-            if (userSessionMap.isEmpty()) {
-                return null; // 맵이 비었으면 roomMemberSessionMap에서 해당 roomId 항목을 제거
-            }
-            return userSessionMap;
+
+            userSessionMap.computeIfPresent(memberId, (mId, info) -> {
+                return sessionId.equals(info.getSessionId()) ? null : info;
+            });
+
+            return userSessionMap.isEmpty() ? null : userSessionMap;
         });
     }
 


### PR DESCRIPTION
## 🔥 Related Issues
<!-- resolved, close, fix 중 하나를 사용하면 머지 시 이슈가 자동으로 닫힙니다 -->
resolved #issue_number

## 💜 작업 내용
<!-- 이번 PR에서 작업한 내용을 체크리스트로 작성해주세요 -->
- [x] ~ 버그수정

## ✅ PR Point
<!-- 리뷰어가 중점적으로 봐야 할 부분을 작성해주세요 -->
- **변경 이유**: 동일 아이디 차단 기능중 새로고침으로 다시 들어가면 두개의 아이디가 모두 참여 가능한것을 수정
## 🧪 테스트 체크리스트
- [x] 로컬에서 정상 작동 확인

